### PR TITLE
Update resolveAppliedStyle.js

### DIFF
--- a/dependencies/lib/resolveAppliedStyle.js
+++ b/dependencies/lib/resolveAppliedStyle.js
@@ -93,7 +93,7 @@
 
                 if (matchesSelectorResult) {
                     potentiallyAppliedStyle = rule.style[style];
-                    if (potentiallyAppliedStyle !== undefined) {
+                    if (potentiallyAppliedStyle !== undefined && potentiallyAppliedStyle !== "") {
 
                         cssStyleSpecificityScore = +(SPECIFICITY.calculate(rule.selectorText)[0]
                             .specificity


### PR DESCRIPTION
Added check for potentiallyAppliedStyle !== "". All styles that i saw would default to "". Which would result in a more specific rule that would have for example height "" instead of height "100%".

Note i used resolveAppliedStyle and SPECIFICITY outside of this project when i stumbled on this issue. But i would suspect this issue would occur in every situation?

e.g.  element: <div id="container" class="part"></div>

 external stylesheet - >  .part{ left: 0,  height: "100%" }
inside html style block (after external style definition) ->  #container {left: "50%"}
would result in the resolvedStyle for height of "".

It wou
